### PR TITLE
최근 검색 기록 localstorage 적용 및 구현

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -161,3 +161,26 @@ function removeFromLocalStorage(username) {
   recentSearches = recentSearches.filter((item) => item !== username); // 선택된 username 삭제
   localStorage.setItem("recentSearches", JSON.stringify(recentSearches));
 }
+
+const searchNameContent = document.querySelector(".search-name-content"); // 최근 검색
+const searchBoxLine = document.querySelector(".search-box-line"); // 검색 상자 하단 라인
+
+// 검색 중 또는 검색 전 상태에 따라 요소 숨기기/보이기
+function toggleSearchExtras(isSearching) {
+  const displayValue = isSearching ? "none" : "block";
+  searchNameContent.style.display = displayValue;
+  searchBoxLine.style.display = displayValue;
+}
+
+// 검색 입력 이벤트 리스너
+searchInput.addEventListener("input", () => {
+  const searchText = searchInput.value.trim().toLowerCase();
+
+  if (searchText !== "") {
+    filterSearchResults(searchText);
+    toggleSearchExtras(true); // 검색 중이므로 숨김
+  } else {
+    showRecentSearches();
+    toggleSearchExtras(false); // 검색어가 없으므로 표시
+  }
+});

--- a/js/search.js
+++ b/js/search.js
@@ -17,11 +17,16 @@ async function loadUsers() {
 
 searchInput.addEventListener("input", () => {
   const searchText = searchInput.value.trim().toLowerCase();
-  if (searchText != "") {
+  if (searchText !== "") {
     filterSearchResults(searchText);
   } else {
-    clearSearchResults();
+    showRecentSearches();
   }
+});
+
+// 페이지 로드 시 최근 검색어 표시
+window.addEventListener("DOMContentLoaded", () => {
+  showRecentSearches();
 });
 
 function filterSearchResults(searchText) {
@@ -42,6 +47,11 @@ function filterSearchResults(searchText) {
     const userElement = document.createElement("div");
     userElement.classList.add("search-list-style");
     userElement.style.display = "flex";
+
+    userElement.addEventListener("click", () => {
+      saveToLocalStorage(user.username);
+      // 검색 중이던 내용은 유지하기 때문에 showRecentSearches() 호출 제거
+    });
 
     const profileBox = document.createElement("div");
     profileBox.classList.add("search-list-box");
@@ -79,4 +89,75 @@ function filterSearchResults(searchText) {
 
 function clearSearchResults() {
   searchListContainer.innerHTML = "";
+}
+
+// localStorage에 username 저장하는 함수
+function saveToLocalStorage(username) {
+  let recentSearches = JSON.parse(localStorage.getItem("recentSearches")) || [];
+  if (!recentSearches.includes(username)) {
+    recentSearches.unshift(username); // 가장 최근 검색어를 앞에 추가
+    if (recentSearches.length > 10) recentSearches.pop(); // 최대 10개 유지
+  }
+  localStorage.setItem("recentSearches", JSON.stringify(recentSearches));
+}
+
+function showRecentSearches() {
+  clearSearchResults(); // 기존 결과 초기화
+
+  const recentSearches = JSON.parse(localStorage.getItem("recentSearches")) || [];
+  if (recentSearches.length === 0) {
+    console.log("최근 검색 항목이 없습니다.");
+    return;
+  }
+
+  const recentUsers = users.filter((user) => recentSearches.includes(user.username));
+  recentUsers.forEach((user) => {
+    const userElement = document.createElement("div");
+    userElement.classList.add("search-list-style");
+    userElement.style.display = "flex";
+
+    const profileBox = document.createElement("div");
+    profileBox.classList.add("search-list-box");
+    const profileImg = document.createElement("img");
+    profileImg.classList.add("search-profile");
+    profileImg.src = user.profileImage;
+    profileBox.appendChild(profileImg);
+
+    const textBox = document.createElement("div");
+    textBox.classList.add("search-list-text-box");
+
+    const username = document.createElement("span");
+    username.classList.add("list-id");
+    username.textContent = user.username;
+
+    const name = document.createElement("span");
+    name.classList.add("list-name");
+    name.textContent = user.name;
+
+    textBox.appendChild(username);
+    textBox.appendChild(name);
+
+    const deleteBtn = document.createElement("div");
+    deleteBtn.classList.add("list-delete");
+    deleteBtn.textContent = "X";
+
+    // 삭제 버튼 클릭 이벤트
+    deleteBtn.addEventListener("click", (event) => {
+      event.stopPropagation(); // 부모 요소 클릭 방지
+      removeFromLocalStorage(user.username);
+      showRecentSearches(); // 삭제 후 업데이트된 최근 검색어 표시
+    });
+
+    userElement.appendChild(profileBox);
+    userElement.appendChild(textBox);
+    userElement.appendChild(deleteBtn);
+
+    searchListContainer.appendChild(userElement);
+  });
+}
+
+function removeFromLocalStorage(username) {
+  let recentSearches = JSON.parse(localStorage.getItem("recentSearches")) || [];
+  recentSearches = recentSearches.filter((item) => item !== username); // 선택된 username 삭제
+  localStorage.setItem("recentSearches", JSON.stringify(recentSearches));
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -547,6 +547,13 @@ body.dark-mode .main-profile-more-icon:active {
     cursor: pointer;
 }
 
+body.dark-mode .story-item p {
+    margin: 5px 0 0;
+    color: #f5f5f5;
+    font-size: 12px;
+    text-align: center;
+}
+
 /* 스토리 부분 */
 .main-story {
     margin-bottom: 24px;

--- a/styles/index.css
+++ b/styles/index.css
@@ -598,7 +598,7 @@ body.dark-mode .story-item p {
     flex-direction: column;
     align-items: center;
     position: relative;
-    min-width: 75px;
+    min-width: 76px;
 }
 
 .story-item img {


### PR DESCRIPTION
# PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]  기능 추가
- [ ]  기능 삭제
- [x]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
feature/main -> develop

# 변경 사항
1. 최근 검색 항목 기능을 사용할 수 있습니다 ! (검색 후 필터링 된 프로필을 클릭할 시, 최근 검색 항목으로 저장됩니다)
2. 검색 텍스트 박스에 검색어가 있으면 필터링이, 없으면 최근 검색 항목이 실시간으로 보이게 적용됩니다
3. 검색 중에는 최근 검색 항목 메뉴와 중간 구분선이 등장하지 않도록 구현했습니다
4. 최근 검색 항목에 등장한 프로필은 우측 X 를 클릭해 삭제할 수 있도록 구현했습니다

전에 부탁 주셨던 메인 페이지 스토리 닉네임 다크 모드 수정 진행했습니다 ! 
(다크 모드일 때 아주 조금 숨겨진 다음 항목이 보여서 간격 조정 1px 도 같이 했습니다 ㅠ)

## 테스트 결과
![스크린샷 2024-12-17 오후 6 37 25](https://github.com/user-attachments/assets/37b823da-963c-4f74-8af5-da42f19addf6)
검색 중일 때
![스크린샷 2024-12-17 오후 6 37 42](https://github.com/user-attachments/assets/df2f2c7f-5efc-48f4-8e5a-59aaeaa6752f)
검색어가 없을 때
![스크린샷 2024-12-17 오후 7 09 13](https://github.com/user-attachments/assets/6fac55e4-3f2e-44b4-bf8c-253df9aa9941)
메인 페이지 스토리

