### PR TITLE
사이드바 서치버튼 주석 해제

### DIFF
--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -24,12 +24,11 @@ export function loadButtonActions() {
 		modeMenu.classList.toggle("hidden");
 	});
 
-	// 	searchMenu.addEventListener("click", (event) => {
-	// 		event.stopPropagation();
-	// 		modeMenu.classList.add("hidden");
-	// 		moreMenu.classList.add("hidden");
-	// 	});
-
+	searchMenu.addEventListener("click", (event) => {
+		event.stopPropagation();
+		modeMenu.classList.add("hidden");
+		moreMenu.classList.add("hidden");
+	});
 
 	// 페이지 외부 클릭 시 메뉴 닫기
 	document.addEventListener("click", () => {
@@ -56,12 +55,12 @@ export function loadButtonActions() {
 	});
 
 	// 검색 탭 클릭시 메뉴 표시/숨김
-	// searchBtn.addEventListener("click", (event) => {
-	// 	event.stopPropagation();
-	// 	searchMenu.classList.toggle("show");
-	// 	leftcontainer.classList.toggle("small");
-	// 	modeMenu.classList.add("hidden");
-	// });
+	searchBtn.addEventListener("click", (event) => {
+		event.stopPropagation();
+		searchMenu.classList.toggle("show");
+		leftcontainer.classList.toggle("small");
+		modeMenu.classList.add("hidden");
+	});
 
 	// 다크 모드 변환시
 	darkModeToggle.addEventListener("click", (event) => {


### PR DESCRIPTION
# PR 타입(하나 이상의 PR 타입을 선택해주세요)
-  버그 수정

# 반영 브랜치
feature/search-button-rollback-> develop

# 변경 사항
사이드바 버튼 액션 다른 곳에서도 사용할 수 있게 수정하기 위해 주석처리 했던 것 안풀었더니
검색버튼이 동작하지 않네요 ㅎㅎ
수정했습니다!

이 코드 주석 풀면서 다른 탭에서 메뉴 버튼은 누를 수 있는데 그 내부에 모드 전환 버튼 액션은 안됩니다.

